### PR TITLE
Support for undocumented files

### DIFF
--- a/lib/dox/index.js
+++ b/lib/dox/index.js
@@ -253,24 +253,40 @@ var render = exports.render = function(str, file){
         });
     } else {
         for (var i = 0, len = parts.length; i < len; ++i) {
-            var part = parts[i],
-                next = parts[i + 1] || '';
+            var part = parts[i];
+
             // Empty
             if (/^\s*$/.test(part)) {
                 continue;
             // Ignored comment
             } else if (/^!\s*\*/.test(part)) {
                 continue;
-            } else if (/^\#\!\//.test(part)) {
-                continue;
             } else {
-                ++i;
 
                 // Support @ignore and --private
-                if (utils.ignore(part) || (utils.isPrivate(part) && !showPrivate)) continue;
-                var part = part.replace(/^ *\* ?/gm, '');
+                if (utils.ignore(part) || (utils.isPrivate(part) && !showPrivate)) {
+                    ++i;
+                    continue;
+
+                // String looks like a comment. In this case next should be a
+                // code block
+                } else if (/^ *\* ?/gm.test(part)) {
+                    ++i;
+                    var part = part.replace(/^ *\* ?/gm, '');
+                    comment = markdown.toHTML(utils.toMarkdown(part));
+                    next = parts[i] || '';
+
+                // String is a code block. In this case there is no comment for
+                // it and it should go to the right. This is the case for files
+                // do not necessarily begin with comments or files that begin
+                // with a shebang
+                } else {
+                    comment = "";
+                    next = part;
+                }
+
                 blocks.push({
-                   comment: markdown.toHTML(utils.toMarkdown(part)),
+                   comment: comment,
                    code: koala.render(".js", utils.escape(next))
                 });
             }


### PR DESCRIPTION
Hey,

So basically my commit was about supporting undocumented files to be correctly parsed. I started documenting a project with your library but found that when there are no proper docstrings the file gets parsed incorrectly. I basically added a conditional to check when the regex split array was of size 1. In which case there were no docstrings found and there is no documentation yet for the source code.

If you want to see how it works try adding some undocumented javascript code before and after applying this patch.

Thanks!
