### PR TITLE
Fib for Issue#30

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,5 +5,6 @@
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
   "keywords": ["documentation", "docs", "markdown", "jsdoc"],
   "directories": { "lib": "./lib/dox" },
+  "main": "./lib/dox/index",
   "bin": { "dox": "./bin/dox" }
 }


### PR DESCRIPTION
Tool is broken on latest npm + node due to module loader changes.

This small change fixes the [issue 30](https://github.com/visionmedia/dox/issues#issue/30).
