### PR TITLE
Fix for #20

### DIFF
--- a/lib/dox/index.js
+++ b/lib/dox/index.js
@@ -262,7 +262,7 @@ var render = exports.render = function(str, file){
             var part = part.replace(/^ *\* ?/gm, '');
             blocks.push({
                comment: markdown.toHTML(utils.toMarkdown(part)),
-               code: koala.render(".js", utils.escape(next)) 
+               code: koala.render(".js", next)
             });
         }
     }


### PR DESCRIPTION
This is a fix for [issue 20](https://github.com/visionmedia/dox/issues#issue/20).

I may be missing something here but it looks to me that there is no need to escape source of *.js file as it will be processed by syntax highlighter which will result in a proper html.  
