### PR TITLE
Removing tab indentation from before documentation comments.

### DIFF
--- a/lib/dox/index.js
+++ b/lib/dox/index.js
@@ -241,7 +241,9 @@ exports.parse = function(args){
  */
 
 var render = exports.render = function(str, file){
-    var parts = str.split(/\s*\/\*([^]+?)\*\/\s*/g),
+	// this line should replace leading spaces and indentation on comments that are intended to be documentation.
+	str = str.replace(/^[\t]*(\s?\/?\*{1,2})/mg, '$1');
+	var parts = str.split(/\s*\/\*([^]+?)\*\/\s*/g),
         blocks = [];
 
     // Populate blocks


### PR DESCRIPTION
One of the things that has gotten under my wheels using this great doc generator is that: if I am working in a browser code base I am usually nested inside of a closure, maybe in an object definition or other indented code segment when I want to document something. The documentation comments in this area should be aligned with the code so they are indented as well. The original way of handling this was for dox to treat these segments as code blocks. This patch removes the leading tabs on a comment so that markdown will render them properly. I hope you receive this change well and I thank you for making this tool available. It works head and shoulders above the other solutions I have tried.

Regards,
Gabriel
