### PR TITLE
Fix for tab-indented comments

### DIFF
--- a/lib/dox/index.js
+++ b/lib/dox/index.js
@@ -259,7 +259,7 @@ var render = exports.render = function(str, file){
             
             // Support @ignore and --private
             if (utils.ignore(part) || (utils.isPrivate(part) && !showPrivate)) continue;
-            var part = part.replace(/^ *\* ?/gm, '');
+            part = part.replace(/^[ \t]*\* ?/gm, '');
             blocks.push({
                comment: markdown.toHTML(utils.toMarkdown(part)),
                code: koala.render(".js", utils.escape(next)) 


### PR DESCRIPTION
I noticed that this wasn't working, so amended the regex slightly to fix it.

I also noticed that `part` is var'd twice in the same function, so removed the second instance.

Cheers,
Steve
