### PR TITLE
Allow for colons in lines not intended as headers

### DIFF
--- a/lib/dox.js
+++ b/lib/dox.js
@@ -97,7 +97,7 @@ exports.parseComment = function(str) {
     , description = {};
 
   // parse comment body
-  description.full = str.split('\n@')[0].replace(/^([\w ]+):/gm, '## $1');
+  description.full = str.split('\n@')[0].replace(/^([\w ]+):$/gm, '## $1');
   description.summary = description.full.split('\n\n')[0];
   description.body = description.full.split('\n\n').slice(1).join('\n\n');
   comment.description = description;


### PR DESCRIPTION
Sometimes it's important include URLs or object literals in comments. Currently those lines are converted to Markdown headers because of the colon, even if it's in the middle of the line. Example:

``` js
/**
 * Example comment
 * 
 *    {
 *        one: {value: 1}
 *    }
 */
```

is parsed to:

``` md
Example comment

    {
##        one {value: 1}
    }

```

This commit fixes that, only converting lines to headers when the colon is at the end of the line. All tests are passing.
