### PR TITLE
Allow for a space after a function statement's parameters declaration.

### DIFF
--- a/lib/dox.js
+++ b/lib/dox.js
@@ -200,7 +200,7 @@ exports.parseCodeContext = function(str){
   var str = str.split('\n')[0];
 
   // function statement
-  if (/^function (\w+)\(/.exec(str)) {
+  if (/^function (\w+) ?\(/.exec(str)) {
     return {
         type: 'function'
       , name: RegExp.$1


### PR DESCRIPTION
Allows for either style:

``` js
function blah (){}
// … or …
function blah () {}
```
