### PR TITLE
Add support for a few special case JS doc tags

### DIFF
--- a/lib/dox.js
+++ b/lib/dox.js
@@ -171,6 +171,13 @@ exports.parseTag = function(str) {
     case 'memberOf':
       tag.parent = parts.shift();
       break;
+    case 'augments':
+      tag.otherClass = parts.shift();
+      break;
+    case 'borrows':
+      tag.otherMemberName = parts.join(' ').split(' as ')[0];
+      tag.thisMemberName = parts.join(' ').split(' as ')[1];
+      break;
     default:
       tag.string = parts.join(' ');
       break;

--- a/test/dox.test.js
+++ b/test/dox.test.js
@@ -253,7 +253,7 @@ module.exports = {
   'test .parseTag() @author': function(){
     var tag = dox.parseTag('@author Bob Bobson');
     tag.type.should.equal('author');
-    tag.name.should.equal('Bob Bobson');
+    tag.string.should.equal('Bob Bobson');
   },
 
   'test .parseTag() @borrows': function(){


### PR DESCRIPTION
Specifically @memberOf, @augments & @borrows.

I use @memberOf within my html template for displaying dox docs - [https://github.com/olivernn/dox-template](https://github.com/olivernn/dox-template).
