### PR TITLE
Normalize line endings to work better on windows

### DIFF
--- a/lib/dox.js
+++ b/lib/dox.js
@@ -23,7 +23,6 @@ exports.version = '0.3.1';
 
 exports.parseComments = function(js, options){
   options = options || {};
-  //normalize line endings
   js = js.replace(/\r\n/gm, '\n');
 
   var comments = []


### PR DESCRIPTION
When run on windows with files which had line endings of '\r\n' (which is the default for anything pulled from git) it produced \r on the end of each tag, which was leading to double line breaks for all my tags when rendered in my template.  This isn't too important for html, but really messes up markdown outputs.
