### PR TITLE
Support uncommented files

### DIFF
--- a/lib/dox.js
+++ b/lib/dox.js
@@ -63,6 +63,14 @@ exports.parseComments = function(js, options){
     }
   }
 
+  if (comments.length === 0) {
+    comments.push({
+      tags: [],
+      description: {full: '', summary: '', body: ''},
+      isPrivate: false
+    });
+  }
+
   // trailing code
   if (buf.trim().length) {
     comment = comments[comments.length - 1];

--- a/test/dox.test.js
+++ b/test/dox.test.js
@@ -283,5 +283,14 @@ module.exports = {
     var tag = dox.parseTag('@hello universe is better than world');
     tag.type.should.equal('hello');
     tag.string.should.equal('universe is better than world');
-  }
+  },
+
+  'test .parseComments() code with no comments': function(done){
+    fixture('uncommented.js', function(err, str){
+      var comments = dox.parseComments(str)
+        , all = comments.shift();
+      all.code.should.equal("function foo() {\n  doSomething();\n}");
+      done();
+    });
+  },
 };

--- a/test/fixtures/uncommented.js
+++ b/test/fixtures/uncommented.js
@@ -1,0 +1,3 @@
+function foo() {
+  doSomething();
+}


### PR DESCRIPTION
At the moment uncommented files cause the exception:

```
Type Error: Cannot set property 'code' of undefined
```

Which is a little confusing if you expect it to just work.  This fix instead makes it return a single element with the same structure as any other comment, but with all fields blank except code, which contains the entire code of the file.
