### PR TITLE
Single line comment test and correction

### DIFF
--- a/lib/dox.js
+++ b/lib/dox.js
@@ -59,7 +59,6 @@ exports.parseComments = function(js, options){
       withinMultiline = ignore = false;
       buf = '';
     } else if (!withinSingle && !withinMultiline && '/' == js[i] && '/' == js[i+1]) {
-      i += 2;
       withinSingle = true;
       buf += js[i];
     } else if (withinSingle && !withinMultiline && '\n' == js[i]) {

--- a/test/dox.test.js
+++ b/test/dox.test.js
@@ -302,4 +302,13 @@ module.exports = {
       done();
     });
   },
+
+  'test .parseComments() with a simple single line comment in code': function(done){
+    fixture('singleline.js', function(err, str){
+      var comments = dox.parseComments(str)
+        , all = comments.shift();
+      all.code.should.equal("function foo() {\n  // Maybe useful\n  doSomething();\n}");
+      done();
+    });
+  },
 };

--- a/test/fixtures/singleline.js
+++ b/test/fixtures/singleline.js
@@ -1,0 +1,7 @@
+/**
+ * Code below must contain the useful comment
+ */
+function foo() {
+  // Maybe useful
+  doSomething();
+}


### PR DESCRIPTION
With a code like this : 

``` javascript
/**
 * Code below must contain the useful comment
 */
function foo() {
  // Maybe useful
  doSomething();
}
```

The "//" before is removed by dox and the comment code result is : 

``` javascript
function foo() {
     Maybe useful
  doSomething();
}
```

So I suggest a test and a correction in this PR. 
Thanks !
