### PR TITLE
find method ctx on nested objects

### DIFF
--- a/lib/dox.js
+++ b/lib/dox.js
@@ -271,7 +271,7 @@ exports.parseCodeContext = function(str){
       , string: RegExp.$1 + '.prototype' + RegExp.$2
     };
   // method
-  } else if (/^(\w+)\.(\w+) *= *function/.exec(str)) {
+  } else if (/^([\w.]+)\.(\w+) *= *function/.exec(str)) {
     return {
         type: 'method'
       , receiver: RegExp.$1


### PR DESCRIPTION
`module.exports.foo = function(){};` doesn't get any ctx, but `exports.foo = function(){};` does. This commit expands the regex to accept more than a single level of depth.
