### PR TITLE
[nesting] path construction in comment parser

### DIFF
--- a/lib/dox.js
+++ b/lib/dox.js
@@ -31,6 +31,51 @@ exports.parseComments = function(js, options){
   options = options || {};
   js = js.replace(/\r\n/gm, '\n');
 
+  var currentPath = '/';
+  var bracketSemaphore = '';
+
+  // Warning: assumes brackets are balanced properly
+  function adjustPath(comment){
+    var code = comment.code;
+    var contextName = comment.ctx ? comment.ctx.name : '<anonymous>';
+
+    // store for comparison after reading through the code fragment
+    var bracketSemaphoreCached = bracketSemaphore;
+
+    for (var i = 0, l = code.length; i < l; ++i) {
+
+      // skip over comments
+      if (code[i] === '/' && code[i+1] === '/') {
+        i = code.indexOf('\n', i+2);
+        // if we fell off the end of the string, stop iterating
+        if (i === -1){
+          break;
+        }
+      }
+
+      // increase semaphore -- expect a closing bracket to decrease later
+      if (code[i] === '{') {
+        ++bracketSemaphore;
+      }
+      // closing bracket found; decrease semaphore
+      else if (code[i] === '}') {
+        --bracketSemaphore;
+      }
+    }
+
+    // if bracket semaphore increased, the closure was left open, so nesting occurs;
+    // extend the path with the current context's name.
+    if (bracketSemaphore > bracketSemaphoreCached) {
+      currentPath += contextName + '/';
+    }
+    else if (bracketSemaphore < bracketSemaphoreCached) {
+      // otherwise, remove the number of path fragments equivalent to the amount decremented from the semaphore
+      for (var j = 0; j < bracketSemaphoreCached - bracketSemaphore; ++j) {
+        currentPath = currentPath.substr(0, currentPath.lastIndexOf('/', currentPath.length - 2) + 1);
+      }
+    }
+  }
+
   var comments = []
     , raw = options.raw
     , comment
@@ -49,6 +94,7 @@ exports.parseComments = function(js, options){
         if(comment) {
           comment.code = code = buf.trim();
           comment.ctx = exports.parseCodeContext(code);
+          adjustPath(comment);
         }
         buf = '';
       }
@@ -60,6 +106,7 @@ exports.parseComments = function(js, options){
       i += 2;
       buf = buf.replace(/^ *\* ?/gm, '');
       var comment = exports.parseComment(buf, options);
+      comment.path = currentPath + '';
       comment.ignore = ignore;
       comments.push(comment);
       withinMultiline = ignore = false;

--- a/test/dox.test.js
+++ b/test/dox.test.js
@@ -311,4 +311,21 @@ module.exports = {
       done();
     });
   },
+
+  'test nesting': function(done){
+    fixture('nesting.js', function(err, str){
+      var comments = dox.parseComments(str);
+
+      comments[0].path.should.equal('/');
+      comments[1].path.should.equal('/<anonymous>/');
+      comments[2].path.should.equal('/<anonymous>/AA/');
+      comments[3].path.should.equal('/<anonymous>/');
+      comments[4].path.should.equal('/<anonymous>/BB/');
+      comments[5].path.should.equal('/<anonymous>/BB/');
+      comments[6].path.should.equal('/<anonymous>/BB/CCC/');
+      comments[7].path.should.equal('/');
+      comments[8].path.should.equal('/B/');
+      done();
+    });
+  }
 };

--- a/test/fixtures/nesting.js
+++ b/test/fixtures/nesting.js
@@ -1,0 +1,68 @@
+/**
+ * A
+ */
+(function(){
+  
+  /**
+   * AA
+   */
+  this.AA = function(){
+
+    /**
+     * AAA
+     */
+    function AAA(){
+    }
+
+  };
+
+  /**
+   * BB
+   */
+  this.BB = function(){
+
+    /**
+     * BBB
+     */
+    function BBB(){
+      while(false){}
+    }
+
+    /**
+     * CCC
+     */
+    function CCC(){
+
+      /**
+       * DDD
+       */
+      function DDD(){
+      }
+
+      //{{}W{}{WW{WW{{}
+      if(false){
+        if(false){
+          for(;;){
+            break;
+          }
+        }
+      }
+    }
+
+  };
+
+})();
+
+/**
+ * B
+ */
+function B(){
+
+  /**
+   * DD
+   */
+  function DD(){
+
+  }
+
+}


### PR DESCRIPTION
1. Implemented simple path construction (adjustPath) in parseComments.
2. Added test.
3. Added a fixture for said test.

Without disrupting the way dox already constructs its output, this patch offers a way for people to use the output to build nested structure. For example, having a class with members: paths offer some insight into how your documentation can be structured.
