### PR TITLE
Prevent error when using --api & comments have no example code.

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -20,7 +20,7 @@ module.exports = function(comments){
     .join('\n')
     .replace(/^ *#/gm, '')
 
-  var code = buf.match(/^( {4}[^\n]+\n*)+/gm);
+  var code = buf.match(/^( {4}[^\n]+\n*)+/gm) || [];
 
   code.forEach(function(block){
     var code = block.replace(/^ {4}/gm, '');

--- a/test/dox.test.js
+++ b/test/dox.test.js
@@ -311,4 +311,12 @@ module.exports = {
       done();
     });
   },
+  'test .api() without inline code in comments': function(done) {
+    fixture('a.js', function(err, str){
+      var comments = dox.parseComments(str);
+      var apiDocs = dox.api(comments);
+      apiDocs.should.equal("  - [exports.version](#exportsversion)\n\n## exports.version\n\n  <p>Library version.</p>\n");
+      done();
+    });
+  }
 };


### PR DESCRIPTION
Output if trying to use `--api` flag on anything that doesn't have example code in the comments:

``` php
/usr/local/share/npm/lib/node_modules/dox/lib/api.js:25
  code.forEach(function(block){
       ^
TypeError: Cannot call method 'forEach' of null
    at Object.module.exports [as api] (/usr/local/share/npm/lib/node_modules/dox/lib/api.js:25:8)
    at Socket.<anonymous> (/usr/local/share/npm/lib/node_modules/dox/bin/dox:46:30)
    at Socket.EventEmitter.emit (events.js:93:17)
    at Pipe.onread (net.js:418:51)
```

[The offending line](https://github.com/visionmedia/dox/blob/26e3f936a9f290a755bbb2787a5f1cd250ca221b/lib/api.js#L25):

`````` js
var code = buf.match(/^( {4}[^\n]+\n*)+/gm); // this may return null

code.forEach(function(block){
  var code = block.replace(/^ {4}/gm, '');
  buf = buf.replace(block, '```js\n' + code.trimRight() + '\n```\n');
});
``````

Simply needs to ensure `code` is an array before doing the `forEach`. Patch includes previously failing test.
