### PR TITLE
Add support for 'throws' tag name.

### DIFF
--- a/lib/dox.js
+++ b/lib/dox.js
@@ -188,6 +188,10 @@ exports.parseTag = function(str) {
       tag.otherMemberName = parts.join(' ').split(' as ')[0];
       tag.thisMemberName = parts.join(' ').split(' as ')[1];
       break;
+    case 'throws':
+      tag.types = exports.parseTagTypes(parts.shift());
+      tag.description = parts.join(' ');
+      break;
     default:
       tag.string = parts.join(' ');
       break;


### PR DESCRIPTION
Adapted dox.js' parseType method to add support for @throws descriptions.
