### PR TITLE
add support for disabling parsing of "single star" comments

### DIFF
--- a/lib/dox.js
+++ b/lib/dox.js
@@ -27,6 +27,9 @@ exports.parseComments = function(js, options){
 
   var comments = []
     , raw = options.raw
+    , singleStar = options.singleStar === undefined
+                 ? true
+                 : options.singleStar
     , comment
     , buf = ''
     , ignore
@@ -36,7 +39,7 @@ exports.parseComments = function(js, options){
 
   for (var i = 0, len = js.length; i < len; ++i) {
     // start comment
-    if (!withinMultiline && !withinSingle && '/' == js[i] && '*' == js[i+1]) {
+    if (!withinMultiline && !withinSingle && '/' == js[i] && '*' == js[i+1] && (singleStar || js[i+2] == '*')) {
       // code following previous comment
       if (buf.trim().length) {
         comment = comments[comments.length - 1];
@@ -172,6 +175,7 @@ exports.parseTag = function(str) {
       } else {
         tag.local = parts.join(' ');
       }
+      break;
     case 'api':
       tag.visibility = parts.shift();
       break;

--- a/test/dox.test.js
+++ b/test/dox.test.js
@@ -358,5 +358,30 @@ module.exports = {
       apiDocs.should.equal("  - [exports.version](#exportsversion)\n\n## exports.version\n\n  <p>Library version.</p>\n");
       done();
     });
+  },
+  'test .parseComments() on single star comments with singleStar=false': function (done) {
+    fixture('single.js', function(err, str){
+      var comments = dox.parseComments(str, { singleStar: false });
+
+      comments.should.have.lengthOf(1);
+      comments[0].tags.should.be.empty;
+      comments[0].code.should.be.equal(str.trim());
+      comments[0].description.full.should.be.empty;
+      done();
+    });
+  },
+  'test .parseComments() on single star comments no options': function (done) {
+    fixture('single.js', function(err, str){
+      var comments = dox.parseComments(str);
+
+      comments.should.have.lengthOf(1);
+      comments[0].tags[0].should.be.eql({
+          type: 'return'
+        , types: [ 'Object' ]
+        , description: 'description'
+      });
+      comments[0].description.full.should.be.equal('<p>foo description</p>');
+      done();
+    });
   }
 };

--- a/test/fixtures/single.js
+++ b/test/fixtures/single.js
@@ -1,0 +1,8 @@
+/*
+ * foo description
+ *
+ * @return {Object} description
+ */
+function foo() {
+  return bar
+}


### PR DESCRIPTION
added an option `singleStar` (which defaults to true) to turn off parsing of single star comments (e.g. `/* */`).  also added missing `break` in `parseTag` because ocd.
