### PR TITLE
Added an `optional` flag to a parameter tag. fixes #81

### DIFF
--- a/lib/dox.js
+++ b/lib/dox.js
@@ -158,6 +158,7 @@ exports.parseTag = function(str) {
       tag.types = exports.parseTagTypes(parts.shift());
       tag.name = parts.shift() || '';
       tag.description = parts.join(' ');
+      tag.optional = exports.parseParamOptional(tag);
       break;
     case 'return':
       tag.types = exports.parseTagTypes(parts.shift());
@@ -212,6 +213,24 @@ exports.parseTagTypes = function(str) {
   return str
     .replace(/[{}]/g, '')
     .split(/ *[|,\/] */);
+};
+
+/**
+ * Determine if a parameter is optional.
+ * 
+ * Examples:
+ * JSDoc: {Type} [name]
+ * Google: {Type=} name
+ * TypeScript: {Type?} name
+ *
+ * @param {Object} tag
+ * @return {Boolean}
+ * @api public
+ */
+
+exports.parseParamOptional = function(tag) {
+  var lastTypeChar = tag.types.slice(-1).slice(-1);
+  return tag.name.slice(0,1) === '[' || lastTypeChar === '=' || lastTypeChar === '?';
 };
 
 /**


### PR DESCRIPTION
If a parameter is optional, tag.optional will equal true.

There are three different way to set a parameter is optional (that I know of).
- JSDoc: `{Type} [name]`
- Google: `{Type=} name`
- TypeScript: `{Type?} name`
