### PR TITLE
Allow multiple namespaces deep

### DIFF
--- a/lib/dox.js
+++ b/lib/dox.js
@@ -252,7 +252,7 @@ exports.parseCodeContext = function(str){
       , string: RegExp.$1 + '()'
     };
   // prototype method
-  } else if (/^([\w$]+)\.prototype\.([\w$]+)[ \t]*=[ \t]*function/.exec(str)) {
+  } else if (/^([\w$.]+)\.prototype\.([\w$]+)[ \t]*=[ \t]*function/.exec(str)) {
     return {
         type: 'method'
       , constructor: RegExp.$1
@@ -261,7 +261,7 @@ exports.parseCodeContext = function(str){
       , string: RegExp.$1 + '.prototype.' + RegExp.$2 + '()'
     };
   // prototype property
-  } else if (/^([\w$]+)\.prototype\.([\w$]+)[ \t]*=[ \t]*([^\n;]+)/.exec(str)) {
+  } else if (/^([\w$.]+)\.prototype\.([\w$]+)[ \t]*=[ \t]*([^\n;]+)/.exec(str)) {
     return {
         type: 'property'
       , constructor: RegExp.$1
@@ -279,7 +279,7 @@ exports.parseCodeContext = function(str){
       , string: RegExp.$1 + '.' + RegExp.$2 + '()'
     };
   // property
-  } else if (/^([\w$]+)\.([\w$]+)[ \t]*=[ \t]*([^\n;]+)/.exec(str)) {
+  } else if (/^([\w$.]+)\.([\w$]+)[ \t]*=[ \t]*([^\n;]+)/.exec(str)) {
     return {
         type: 'property'
       , receiver: RegExp.$1


### PR DESCRIPTION
In the code context parsing, the general method parser currently allows for multiple namespaces, e.g. `NS1.NS2.myMethod = ...` through `([\w$.]+)`, but the prototype method and property regexes don't allow this. They instead have `([\w$.]+)`.

Not sure if there's a reason for this, but this PR is a simple patch to make the other regex like the general method one.
