### PR TITLE
more tags for google closure and multiline tag support

### DIFF
--- a/lib/dox.js
+++ b/lib/dox.js
@@ -113,18 +113,18 @@ exports.parseComment = function(str, options) {
 
   var comment = { tags: [] }
     , raw = options.raw
-    , description = {};
+    , description = {}
+    , tags = str.split('\n@');
 
   // parse comment body
-  description.full = str.split('\n@')[0];
+  description.full = tags[0];
   description.summary = description.full.split('\n\n')[0];
   description.body = description.full.split('\n\n').slice(1).join('\n\n');
   comment.description = description;
 
   // parse tags
-  if (~str.indexOf('\n@')) {
-    var tags = '@' + str.split('\n@').slice(1).join('\n@');
-    comment.tags = tags.split('\n').map(exports.parseTag);
+  if (tags.length) {
+    comment.tags = tags.slice(1).map(exports.parseTag);
     comment.isPrivate = comment.tags.some(function(tag){
       return 'private' == tag.visibility;
     })
@@ -150,8 +150,13 @@ exports.parseComment = function(str, options) {
 
 exports.parseTag = function(str) {
   var tag = {}
-    , parts = str.split(/ +/)
+    , lines = str.split('\n')
+    , parts = lines[0].split(/ +/)
     , type = tag.type = parts.shift().replace('@', '');
+
+  if (lines.length > 1) {
+    parts.push(lines.slice(1).join('\n'));
+  }
 
   switch (type) {
     case 'property':

--- a/test/dox.multilinetags.test.js
+++ b/test/dox.multilinetags.test.js
@@ -1,0 +1,101 @@
+/**
+ * Module dependencies.
+ */
+
+var dox = require('../')
+  , should = require('should')
+  , fs = require('fs');
+
+function fixture(name, fn) {
+  fs.readFile(__dirname + '/fixtures/' + name, 'utf8', fn);
+}
+
+module.exports = {
+  'test .parseComments() multiline tags': function(done){
+    fixture('multilinetags.js', function(err, str){
+      var comments = dox.parseComments(str)
+        , only = comments.shift()
+        , first = comments.shift()
+        , last = comments.shift()
+        , mid = comments.shift()
+        , onlyParam = comments.shift()
+        , firstParam = comments.shift()
+        , lastParam = comments.shift()
+        , midParam = comments.shift()
+        , onlyReturn = comments.shift()
+        , firstReturn = comments.shift()
+        , lastReturn = comments.shift()
+        , midReturn = comments.shift();
+      console.log('only=', only);
+      console.log('first=', first);
+      console.log('last=', last);
+      console.log('mid=', mid);
+      console.log('onlyReturn=', onlyReturn.tags);
+      console.log('firstReturn=', firstReturn.tags);
+      console.log('lastReturn=', lastReturn.tags);
+      console.log('midReturn=', midReturn.tags);
+
+      only.tags.should.with.lengthOf(1);
+      only.tags[0].string.should.equal('one\ntwo\nthree');
+      first.tags.should.with.lengthOf(2);
+      first.tags[0].string.should.equal('one\ntwo\nthree');
+      first.tags[1].string.should.equal('last');
+      last.tags.should.with.lengthOf(2);
+      last.tags[0].string.should.equal('first');
+      last.tags[1].string.should.equal('one\ntwo\nthree');
+      mid.tags.should.with.lengthOf(3);
+      mid.tags[0].string.should.equal('first');
+      mid.tags[1].string.should.equal('one\ntwo\nthree');
+      mid.tags[2].string.should.equal('last');
+
+      onlyParam.tags.should.with.lengthOf(1);
+      onlyParam.tags[0].type.should.equal('param');
+      onlyParam.tags[0].name.should.equal('foo');
+      onlyParam.tags[0].types.should.eql(['String']);
+      onlyParam.tags[0].description.should.equal('one\ntwo\nthree');
+      firstParam.tags.should.with.lengthOf(2);
+      firstParam.tags[0].type.should.equal('param');
+      firstParam.tags[0].name.should.equal('foo');
+      firstParam.tags[0].types.should.eql(['String']);
+      firstParam.tags[0].description.should.equal('one\ntwo\nthree');
+      firstParam.tags[1].string.should.equal('last');
+      lastParam.tags.should.with.lengthOf(2);
+      lastParam.tags[0].string.should.equal('first');
+      lastParam.tags[1].type.should.equal('param');
+      lastParam.tags[1].name.should.equal('foo');
+      lastParam.tags[1].types.should.eql(['String']);
+      lastParam.tags[1].description.should.equal('one\ntwo\nthree');
+      midParam.tags.should.with.lengthOf(3);
+      midParam.tags[0].string.should.equal('first');
+      midParam.tags[1].type.should.equal('param');
+      midParam.tags[1].name.should.equal('foo');
+      midParam.tags[1].types.should.eql(['String']);
+      midParam.tags[1].description.should.equal('one\ntwo\nthree');
+      midParam.tags[2].string.should.equal('last');
+
+      onlyReturn.tags.should.with.lengthOf(1);
+      onlyReturn.tags[0].type.should.equal('return');
+      onlyReturn.tags[0].types.should.eql(['String']);
+      onlyReturn.tags[0].description.should.equal('one\ntwo\nthree');
+      firstReturn.tags.should.with.lengthOf(2);
+      firstReturn.tags[0].type.should.equal('return');
+      firstReturn.tags[0].types.should.eql(['String']);
+      firstReturn.tags[0].description.should.equal('one\ntwo\nthree');
+      firstReturn.tags[1].string.should.equal('last');
+      lastReturn.tags.should.with.lengthOf(2);
+      lastReturn.tags[0].string.should.equal('first');
+      lastReturn.tags[1].type.should.equal('return');
+      lastReturn.tags[1].types.should.eql(['String']);
+      lastReturn.tags[1].description.should.equal('one\ntwo\nthree');
+      midReturn.tags.should.with.lengthOf(3);
+      midReturn.tags[0].string.should.equal('first');
+      midReturn.tags[1].type.should.equal('return');
+      midReturn.tags[1].types.should.eql(['String']);
+      midReturn.tags[1].description.should.equal('one\ntwo\nthree');
+      midReturn.tags[2].string.should.equal('last');
+
+      done();
+    });
+  }
+};
+

--- a/test/fixtures/multilinetags.js
+++ b/test/fixtures/multilinetags.js
@@ -1,0 +1,143 @@
+/**
+ * only
+ *
+ * @sample
+ * one
+ * two
+ * three
+ */
+function only() {
+}
+
+/**
+ * first
+ *
+ * @sample
+ * one
+ * two
+ * three
+ * @bar last
+ */
+function first() {
+}
+
+/**
+ * last
+ *
+ * @foo first
+ * @sample
+ * one
+ * two
+ * three
+ */
+function last() {
+}
+
+/**
+ * mid
+ *
+ * @foo first
+ * @sample
+ * one
+ * two
+ * three
+ * @bar last
+ */
+function mid() {
+}
+
+/**
+ * only
+ *
+ * @param {String} foo
+ * one
+ * two
+ * three
+ */
+function onlyParam() {
+}
+
+/**
+ * first
+ *
+ * @param {String} foo
+ * one
+ * two
+ * three
+ * @bar last
+ */
+function firstParam() {
+}
+
+/**
+ * last
+ *
+ * @foo first
+ * @param {String} foo
+ * one
+ * two
+ * three
+ */
+function lastParam() {
+}
+
+/**
+ * mid
+ *
+ * @foo first
+ * @param {String} foo
+ * one
+ * two
+ * three
+ * @bar last
+ */
+function midParam() {
+}
+
+/**
+ * only
+ *
+ * @return {String}
+ * one
+ * two
+ * three
+ */
+function onlyReturn() {
+}
+
+/**
+ * first
+ *
+ * @return {String}
+ * one
+ * two
+ * three
+ * @bar last
+ */
+function firstReturn() {
+}
+
+/**
+ * last
+ *
+ * @foo first
+ * @return {String}
+ * one
+ * two
+ * three
+ */
+function lastReturn() {
+}
+
+/**
+ * mid
+ *
+ * @foo first
+ * @return {String}
+ * one
+ * two
+ * three
+ * @bar last
+ */
+function midReturn() {
+}


### PR DESCRIPTION
- google closure tags
  - @property, @template, @define, @public, @private, @protected, @enum, @typedef, @extends, @implements
  - see  https://developers.google.com/closure/compiler/docs/js-for-compiler
- multiline tags(description or string) such as @example.
  - see test case.
