### PR TITLE
Support for empty description befor @param tag

### DIFF
--- a/lib/dox.js
+++ b/lib/dox.js
@@ -122,19 +122,18 @@ exports.parseComment = function(str, options) {
     comment.description = description;
 
     // parse tags
-    if (~str.indexOf('\n@')) {
 
-        var tags = str.split('\n').filter(function(line){
-            line = line.trim();
-            return line.substr(0,1) == '@';
-        });
-        //var tags = '@' + str.split('\n@').slice(1).join('\n@');
-        //comment.tags = tags.split('\n').map(exports.parseTag);
 
+    var tags = str.split('\n').filter(function(line){
+        line = line.trim();
+        return line.substr(0,1) == '@';
+    });
+
+    if(tags.length > 0){
         comment.tags = tags.map(exports.parseTag);
         comment.isPrivate = comment.tags.some(function(tag){
             return 'api' == tag.type && 'private' == tag.visibility;
-        })
+        });
     }
 
     // markdown

--- a/test/dox.test.js
+++ b/test/dox.test.js
@@ -184,6 +184,15 @@ module.exports = {
     });
   },
 
+   'test .parseComments() tags extended': function(done){
+       fixture('params.js', function(err, str){
+            var comments = dox.parseComments(str);
+            var first = comments.shift();
+            first.tags.should.have.length(1);
+            done();
+       });
+   },
+
   'test .parseComments() code': function(done){
     fixture('b.js', function(err, str){
       var comments = dox.parseComments(str)
@@ -195,6 +204,8 @@ module.exports = {
       done();
     });
   },
+
+
 
   'test .parseComments() titles': function(done){
     fixture('titles.js', function(err, str){

--- a/test/fixtures/params.js
+++ b/test/fixtures/params.js
@@ -1,0 +1,9 @@
+// just params (no description)
+
+/**
+ *
+ * @param {String} bar
+ */
+function Foo(bar) {
+    this.bar = bar
+}


### PR DESCRIPTION
Currently the master does not support parsing the @param tags if description is empty 
Example: 

```
/**
 *
 * @param {String} bar
 */
function Foo(bar) {
    this.bar = bar
} 
```
