### PR TITLE
Prevent crash when no headers are generated.

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -42,7 +42,7 @@ function slug(str) {
 }
 
 function headings(str) {
-  return str.match(/^#+ *([^\n]+)/gm).map(function(str){
+  return (str.match(/^#+ *([^\n]+)/gm) || []).map(function(str){
     str = str.replace(/^(#+) */, '');
     return {
       title: str,


### PR DESCRIPTION
When using the --api flag, dox will crash if it doesn't have any markdown headers to render. Thanks!
