### PR TITLE
Add setMarkedOptions

### DIFF
--- a/lib/dox.js
+++ b/lib/dox.js
@@ -19,7 +19,7 @@ renderer.br = function () {
   return '<br />';
 };
 
-markdown.setOptions({
+var markedOptions = {
   renderer: renderer
 , gfm: true
 , tables: true
@@ -28,7 +28,9 @@ markdown.setOptions({
 , sanitize: false
 , smartLists: true
 , smartypants: false
-});
+};
+
+markdown.setOptions(markedOptions);
 
 /**
  * Expose api.
@@ -303,7 +305,7 @@ exports.parseParamOptional = function(tag) {
  * @api public
  */
 
-exports.parseCodeContext = function(str){
+exports.parseCodeContext = function(str) {
   var str = str.split('\n')[0];
 
   // function statement
@@ -365,4 +367,8 @@ exports.parseCodeContext = function(str){
       , string: RegExp.$1
     };
   }
+};
+
+exports.setMarkedOptions = function(opts) {
+  markdown.setOptions(opts);
 };


### PR DESCRIPTION
Marked is a highly configurable dependency of Dox. It'd be nice to be able to configure marked options to customize the markdown rules that Dox applies.

In my project, I'm setting `breaks` to false and adding a `highlight` function. 
