### PR TITLE
skipPrefixes incorrectly assumes option.raw=false

### DIFF
--- a/lib/dox.js
+++ b/lib/dox.js
@@ -63,7 +63,7 @@ exports.parseComments = function(js, options){
     , withinString = false
     , code
     , linterPrefixes = options.skipPrefixes || ['jslint', 'jshint', 'eshint']
-    , skipPattern = new RegExp('^<p>('+ linterPrefixes.join('|') + ')')
+    , skipPattern = new RegExp('^' + (options.raw ? '' : '<p>') + '('+ linterPrefixes.join('|') + ')')
     , lineNum = 1
     , lineNumStarting = 1
     , parentContext;
@@ -97,11 +97,11 @@ exports.parseComments = function(js, options){
       i += 2;
       withinMultiline = true;
       ignore = '!' == js[i];
-      
+
       // if the current character isn't whitespace and isn't an ignored comment,
       // back up one character so we don't clip the contents
       if (' ' !== js[i] && '\n' !== js[i] && '\t' !== js[i] && '!' !== js[i]) i--;
-      
+
     // end comment
     } else if (withinMultiline && !withinSingle && '*' == js[i] && '/' == js[i+1]) {
       i += 2;
@@ -338,7 +338,7 @@ exports.parseTagTypes = function(str) {
 
 /**
  * Determine if a parameter is optional.
- * 
+ *
  * Examples:
  * JSDoc: {Type} [name]
  * Google: {Type=} name


### PR DESCRIPTION
`skipPrefixes` is incorrectly assuming that `raw` would always be `false`. This checks the conditional before adding `<p>` to the regex.
