### PR TITLE
Fixes parseTagTypes for incorrect tags without type or desc

### DIFF
--- a/lib/dox.js
+++ b/lib/dox.js
@@ -331,6 +331,7 @@ exports.parseTag = function(str) {
  */
 
 exports.parseTagTypes = function(str) {
+  str = str || '';
   return str
     .replace(/[{}]/g, '')
     .split(/ *[|,\/] */);


### PR DESCRIPTION
sometimes people are silly and use tags like @property incorrectly and omit the type and/or name. that causes dox to barf. 

one could argue that the user should fix their jsdoc, but rather than throwing an unexpected exception, let's have dox continue on and ignore the bad syntax.
