### PR TITLE
Parse tag strings with Markdown

### DIFF
--- a/lib/dox.js
+++ b/lib/dox.js
@@ -238,6 +238,7 @@ exports.parseComment = function(str, options) {
     description.body = markdown(description.body);
     comment.tags.forEach(function (tag) {
       if (tag.description) tag.description = markdown(tag.description);
+      if (tag.string && tag.type !== 'alias') tag.string = markdown(tag.string);
     });
   }
 

--- a/test/dox.multilinetags.test.js
+++ b/test/dox.multilinetags.test.js
@@ -29,17 +29,17 @@ module.exports = {
         , example = comments.shift();
 
       only.tags.should.with.lengthOf(1);
-      only.tags[0].string.should.equal('one\ntwo\nthree');
+      only.tags[0].string.should.equal('<p>one<br />two<br />three</p>');
       first.tags.should.with.lengthOf(2);
-      first.tags[0].string.should.equal('one\ntwo\nthree');
-      first.tags[1].string.should.equal('last');
+      first.tags[0].string.should.equal('<p>one<br />two<br />three</p>');
+      first.tags[1].string.should.equal('<p>last</p>');
       last.tags.should.with.lengthOf(2);
-      last.tags[0].string.should.equal('first');
-      last.tags[1].string.should.equal('one\ntwo\nthree');
+      last.tags[0].string.should.equal('<p>first</p>');
+      last.tags[1].string.should.equal('<p>one<br />two<br />three</p>');
       mid.tags.should.with.lengthOf(3);
-      mid.tags[0].string.should.equal('first');
-      mid.tags[1].string.should.equal('one\ntwo\nthree');
-      mid.tags[2].string.should.equal('last');
+      mid.tags[0].string.should.equal('<p>first</p>');
+      mid.tags[1].string.should.equal('<p>one<br />two<br />three</p>');
+      mid.tags[2].string.should.equal('<p>last</p>');
 
       onlyParam.tags.should.with.lengthOf(1);
       onlyParam.tags[0].type.should.equal('param');
@@ -51,20 +51,20 @@ module.exports = {
       firstParam.tags[0].name.should.equal('foo');
       firstParam.tags[0].types.should.eql(['String']);
       firstParam.tags[0].description.should.equal('<p>one<br />two<br />three</p>');
-      firstParam.tags[1].string.should.equal('last');
+      firstParam.tags[1].string.should.equal('<p>last</p>');
       lastParam.tags.should.with.lengthOf(2);
-      lastParam.tags[0].string.should.equal('first');
+      lastParam.tags[0].string.should.equal('<p>first</p>');
       lastParam.tags[1].type.should.equal('param');
       lastParam.tags[1].name.should.equal('foo');
       lastParam.tags[1].types.should.eql(['String']);
       lastParam.tags[1].description.should.equal('<p>one<br />two<br />three</p>');
       midParam.tags.should.with.lengthOf(3);
-      midParam.tags[0].string.should.equal('first');
+      midParam.tags[0].string.should.equal('<p>first</p>');
       midParam.tags[1].type.should.equal('param');
       midParam.tags[1].name.should.equal('foo');
       midParam.tags[1].types.should.eql(['String']);
       midParam.tags[1].description.should.equal('<p>one<br />two<br />three</p>');
-      midParam.tags[2].string.should.equal('last');
+      midParam.tags[2].string.should.equal('<p>last</p>');
 
       onlyReturn.tags.should.with.lengthOf(1);
       onlyReturn.tags[0].type.should.equal('return');
@@ -74,21 +74,21 @@ module.exports = {
       firstReturn.tags[0].type.should.equal('return');
       firstReturn.tags[0].types.should.eql(['String']);
       firstReturn.tags[0].description.should.equal('<p>one<br />two<br />three</p>');
-      firstReturn.tags[1].string.should.equal('last');
+      firstReturn.tags[1].string.should.equal('<p>last</p>');
       lastReturn.tags.should.with.lengthOf(2);
-      lastReturn.tags[0].string.should.equal('first');
+      lastReturn.tags[0].string.should.equal('<p>first</p>');
       lastReturn.tags[1].type.should.equal('return');
       lastReturn.tags[1].types.should.eql(['String']);
       lastReturn.tags[1].description.should.equal('<p>one<br />two<br />three</p>');
       midReturn.tags.should.with.lengthOf(3);
-      midReturn.tags[0].string.should.equal('first');
+      midReturn.tags[0].string.should.equal('<p>first</p>');
       midReturn.tags[1].type.should.equal('return');
       midReturn.tags[1].types.should.eql(['String']);
       midReturn.tags[1].description.should.equal('<p>one<br />two<br />three</p>');
-      midReturn.tags[2].string.should.equal('last');
+      midReturn.tags[2].string.should.equal('<p>last</p>');
 
       example.tags.should.with.lengthOf(1);
-      example.tags[0].string.should.equal('    test(one);\n    test(two);');
+      example.tags[0].string.should.equal('<pre><code>test(one);\ntest(two);\n</code></pre>');
       done();
     });
   }

--- a/test/dox.test.js
+++ b/test/dox.test.js
@@ -140,12 +140,13 @@ module.exports = {
       parseTagTypes.codeStart.should.equal(172);
 
       var escape = comments.pop();
-      escape.tags.should.have.length(3);
+      escape.tags.should.have.length(4);
+      escape.tags[3].string.should.equal('<p>With <code>Markdown</code> syntax</p>')
       escape.description.full.should.equal('<p>Escape the given <code>html</code>.</p>');
       escape.ctx.type.should.equal('function');
       escape.ctx.name.should.equal('escape');
       escape.line.should.equal(253);
-      escape.codeStart.should.equal(261);
+      escape.codeStart.should.equal(262);
       done();
     });
   },

--- a/test/fixtures/c.js
+++ b/test/fixtures/c.js
@@ -256,6 +256,7 @@ exports.parseCodeContext = function(str){
  * @param {String} html
  * @return {String}
  * @api private
+ * @custom With `Markdown` syntax
  */
 
 function escape(html){


### PR DESCRIPTION
[Dox was just recently updated to parse Markdown in tag descriptions](https://github.com/tj/dox/commit/08995f528c7aa33d23a6f1107f7080263d8b28c7), but it does not (currently) do the same for the `string` property of tag objects. (The `string` property is used in place of `description` for tags which do not include a "type" specifier.) Here's an example usage:

```js
/**
 * This option enforces the consistency of quotation marks used throughout
 * your code. It accepts three values: `true` if you don't want to enforce
 * one particular style but want some consistency, `"single"` if you want to
 * allow only single quotes and `"double"` if you want to allow only double
 * quotes.
 *
 * @deprecated JSHint is moving away from enforcing stylistic concerns. Check
 *             out [the JSCS project](https://github.com/jscs-dev/node-jscs)
 *             for similiar functionality.
 */
```

Note that I've had to special-case the `alias` tag. I think this makes sense, but I'd welcome input from a maintainer.