### PR TITLE
Add regexp to recognize returned closure functions.

### DIFF
--- a/lib/dox.js
+++ b/lib/dox.js
@@ -507,6 +507,13 @@ exports.parseCodeContext = function(str, parentContext) {
       , string: RegExp.$1 + '()'
     };
   // function expression
+  } else if (/^return\s+function(?:\s+([\w$]+))?\s*\(/.exec(str)) {
+    return {
+        type: 'function'
+      , name: RegExp.$1
+      , string: RegExp.$1 + '()'
+    };
+  // function expression
   } else if (/^\s*var\s+([\w$]+)\s*=\s*function/.exec(str)) {
     return {
         type: 'function'

--- a/test/dox.test.js
+++ b/test/dox.test.js
@@ -489,6 +489,18 @@ module.exports = {
     ctx.name.should.equal('$foo');
   },
 
+  'test .parseCodeContext() returned unnamed function statement': function(){
+    var ctx = dox.parseCodeContext('return function (){\n\n}');
+    ctx.type.should.equal('function');
+    ctx.name.should.equal('');
+  },
+
+  'test .parseCodeContext() returned named function statement': function(){
+    var ctx = dox.parseCodeContext('return function $foo (){\n\n}');
+    ctx.type.should.equal('function');
+    ctx.name.should.equal('$foo');
+  },
+
   'test .parseCodeContext() function expression': function(){
     var ctx = dox.parseCodeContext('var $foo = function(){\n\n}');
     ctx.type.should.equal('function');


### PR DESCRIPTION
Makes it possible for dox to recognize a directly returned closure as a valid function.