### PR TITLE
Allow optional types on tags

### DIFF
--- a/lib/dox.js
+++ b/lib/dox.js
@@ -387,13 +387,6 @@ exports.parseTag = function(str) {
 };
 
 /**
- * Check if a string is a tag type.
- *
- * @param {String} type
- * @return {boolean}
- */
-
-/**
  * Parse tag type string "{Array|Object}" etc.
  * This function also supports complex type descriptors like in jsDoc or even the enhanced syntax used by the
  * [google closure compiler](https://developers.google.com/closure/compiler/docs/js-for-compiler#types)

--- a/lib/dox.js
+++ b/lib/dox.js
@@ -415,7 +415,12 @@ exports.parseTag = function(str) {
  */
 
 exports.parseTagTypes = function(str, tag) {
-  if (!str || str.length < 3 || str[0] !== '{' || str.substr(-1) !== '}') {
+  if (!str) {
+    if(tag) {
+      tag.types = [];
+      tag.typesDescription = "";
+      tag.optional = tag.nullable = tag.nonNullable = tag.variable = false;
+    }
     return [];
   }
   var Parser = require('jsdoctypeparser').Parser;

--- a/lib/dox.js
+++ b/lib/dox.js
@@ -307,7 +307,8 @@ exports.parseTag = function(str) {
     , lines = str.split('\n')
     , parts = exports.extractTagParts(lines[0])
     , type = tag.type = parts.shift().replace('@', '')
-    , matchType = new RegExp('^@?' + type + ' *');
+    , matchType = new RegExp('^@?' + type + ' *')
+    , matchTypeStr = /^\{.+\}$/;
 
   tag.string = str.replace(matchType, '');
 
@@ -319,7 +320,7 @@ exports.parseTag = function(str) {
     case 'property':
     case 'template':
     case 'param':
-      var typeString = parts.shift();
+      var typeString = matchTypeStr.test(parts[0]) ? parts.shift() : "";
       tag.name = parts.shift() || '';
       tag.description = parts.join(' ');
       exports.parseTagTypes(typeString, tag);
@@ -327,7 +328,8 @@ exports.parseTag = function(str) {
     case 'define':
     case 'return':
     case 'returns':
-      exports.parseTagTypes(parts.shift(), tag);
+      var typeString = matchTypeStr.test(parts[0]) ? parts.shift() : "";
+      exports.parseTagTypes(typeString, tag);
       tag.description = parts.join(' ');
       break;
     case 'see':
@@ -367,7 +369,8 @@ exports.parseTag = function(str) {
       tag.thisMemberName = parts.join(' ').split(' as ')[1];
       break;
     case 'throws':
-      tag.types = exports.parseTagTypes(parts.shift());
+      var typeString = matchTypeStr.test(parts[0]) ? parts.shift() : "";
+      tag.types = exports.parseTagTypes(typeString);
       tag.description = parts.join(' ');
       break;
     case 'description':
@@ -382,6 +385,13 @@ exports.parseTag = function(str) {
 
   return tag;
 };
+
+/**
+ * Check if a string is a tag type.
+ *
+ * @param {String} type
+ * @return {boolean}
+ */
 
 /**
  * Parse tag type string "{Array|Object}" etc.

--- a/lib/dox.js
+++ b/lib/dox.js
@@ -405,6 +405,9 @@ exports.parseTag = function(str) {
  */
 
 exports.parseTagTypes = function(str, tag) {
+  if (!str || str.length < 3 || str[0] !== '{' || str.substr(-1) !== '}') {
+    return [];
+  }
   var Parser = require('jsdoctypeparser').Parser;
   var Builder = require('jsdoctypeparser').Builder;
   var result = new Parser().parse(str.substr(1, str.length - 2));

--- a/test/dox.test.js
+++ b/test/dox.test.js
@@ -896,10 +896,12 @@ module.exports = {
       comments.length.should.equal(2);
       comments[0].description.full.should.equal("<p>FSM states.</p>");
       comments[0].tags[0].type.should.equal("enum");
+      comments[0].tags[0].types.length.should.equal(0);
       comments[0].tags[0].string.should.equal("");
 
       comments[1].description.full.should.equal("<p>Colors.</p>");
       comments[1].tags[0].type.should.equal("enum");
+      comments[0].tags[0].types.length.should.equal(0);
       comments[1].tags[0].string.should.equal("");
       done();
     });

--- a/test/dox.test.js
+++ b/test/dox.test.js
@@ -888,5 +888,20 @@ module.exports = {
       comments[1].isEvent.should.be.true;
       done();
     });
+  },
+
+  'test optional types': function (done) {
+    fixture('enums.js', function (err, str){
+      var comments = dox.parseComments(str);
+      comments.length.should.equal(2);
+      comments[0].description.full.should.equal("<p>FSM states.</p>");
+      comments[0].tags[0].type.should.equal("enum");
+      comments[0].tags[0].string.should.equal("");
+
+      comments[1].description.full.should.equal("<p>Colors.</p>");
+      comments[1].tags[0].type.should.equal("enum");
+      comments[1].tags[0].string.should.equal("");
+      done();
+    });
   }
 };

--- a/test/dox.test.js
+++ b/test/dox.test.js
@@ -890,7 +890,7 @@ module.exports = {
     });
   },
 
-  'test optional types': function (done) {
+  'test optional types for @enum': function (done) {
     fixture('enums.js', function (err, str){
       var comments = dox.parseComments(str);
       comments.length.should.equal(2);
@@ -901,6 +901,25 @@ module.exports = {
       comments[1].description.full.should.equal("<p>Colors.</p>");
       comments[1].tags[0].type.should.equal("enum");
       comments[1].tags[0].string.should.equal("");
+      done();
+    });
+  },
+
+  'test optional types for @throws': function (done) {
+    fixture('throws.js', function (err, str){
+      var comments = dox.parseComments(str);
+      comments.length.should.equal(2);
+      comments[0].description.full.should.equal("<p>Raise an exception for fun.</p>");
+      comments[0].tags[0].type.should.equal("throws");
+      comments[0].tags[0].types.length.should.equal(0);
+      comments[0].tags[0].string.should.equal("An error message.");
+      comments[0].tags[0].description.should.equal("<p>An error message.</p>");
+
+      comments[1].description.full.should.equal("<p>Validate user input.</p>");
+      comments[1].tags[0].type.should.equal("throws");
+      comments[1].tags[0].types[0].should.equal("TypeError");
+      comments[1].tags[0].string.should.equal("{TypeError} Invalid argument.");
+      comments[1].tags[0].description.should.equal("<p>Invalid argument.</p>");
       done();
     });
   }

--- a/test/fixtures/enums.js
+++ b/test/fixtures/enums.js
@@ -1,0 +1,23 @@
+/**
+ * FSM states.
+ *
+ * @enum
+ */
+FSM.prototype.states = {
+    STOPPED     : 0,
+    STARTING    : 1,
+    WORKING     : 2,
+    STOPPING    : 3
+};
+
+
+/**
+ * Colors.
+ *
+ * @enum
+ */
+exports.RED     = "#f00";
+exports.GREEN   = "#0f0";
+exports.BLUE    = "#00f";
+exports.BLACK   = "#000";
+exports.WHITE   = "#fff";

--- a/test/fixtures/throws.js
+++ b/test/fixtures/throws.js
@@ -1,0 +1,20 @@
+/**
+ * Raise an exception for fun.
+ *
+ * @throws An error message.
+ */
+function crashMe() {
+    throw "Bang!";
+}
+
+/**
+ * Validate user input.
+ *
+ * @throws {TypeError} Invalid argument.
+ */
+function validateUserInput(input) {
+    if (typeof input !== "string")) {
+        throw new TypeError("Input is not a string");
+    }
+    return true;
+}


### PR DESCRIPTION
- Some tags allow optional inclusion of a type:
- @enum : http://usejsdoc.org/tags-enum.html
- @typedef : http://usejsdoc.org/tags-typedef.html
- @param : http://usejsdoc.org/tags-param.html
- @throws : http://usejsdoc.org/tags-throws.html

Fixes exceptions when a tag is missing its optional type. E.g.:

```javascript
/**
 * Testing!
 * @name test
 * @enum
 */
```

Raises an exception:

```
TypeError: Cannot read property 'substr' of undefined
    at Object.exports.parseTagTypes (.../node_modules/dox/lib/dox.js:413:38)
    at exports.parseTag (.../node_modules/dox/lib/dox.js:357:15)
    at Array.map (native)
    at Object.exports.parseComment (.../node_modules/dox/lib/dox.js:223:34)
    at Object.exports.parseComments (.../node_modules/dox/lib/dox.js:112:25)
```