### PR TITLE
Single quotes are not properly handled

### DIFF
--- a/test/dox.test.js
+++ b/test/dox.test.js
@@ -924,5 +924,13 @@ module.exports = {
       comments[1].tags[0].description.should.equal("<p>Invalid argument.</p>");
       done();
     });
+  },
+
+  'can properly handle escaped single quotes': function (done) {
+    fixture('error.js', function (err, str) {
+      var comments = dox.parseComments(str);
+      comments.length.should.equal(2);
+      done();
+    })
   }
 };

--- a/test/fixtures/error.js
+++ b/test/fixtures/error.js
@@ -1,0 +1,16 @@
+/**
+ * Thrower - description
+ *
+ * @class Thrower
+ */
+function Thrower () {
+  throw new Error('Something hasn\'t been defined.');
+}
+
+
+/**
+ * anonymous function - description
+ *
+ * @return {type}  description
+ */
+Thrower.prototype.foo = function () {};


### PR DESCRIPTION
If the line is changed from 

```
throw new Error('Something hasn\'t been defined.');
```

to

```
throw new Error('Something has not been defined.');
```

it will work.