### PR TITLE
Fix incorrect string quoting issues

### DIFF
--- a/lib/dox.js
+++ b/lib/dox.js
@@ -64,10 +64,14 @@ exports.parseComments = function(js, options){
     , skipPattern = new RegExp('^' + (options.raw ? '' : '<p>') + '('+ linterPrefixes.join('|') + ')')
     , lineNum = 1
     , lineNumStarting = 1
-    , parentContext;
+    , parentContext
+    , withinEscapeChar
+    , currentStringQuoteChar;
 
 
   for (var i = 0, len = js.length; i < len; ++i) {
+    withinEscapeChar = withinString && !withinEscapeChar && js[i - 1] == '\\';
+
     // start comment
     if (!withinMultiline && !withinSingle && !withinString &&
         '/' == js[i] && '*' == js[i+1] && (!skipSingleStar || js[i+2] == '*')) {
@@ -124,8 +128,16 @@ exports.parseComments = function(js, options){
     } else if (withinSingle && !withinMultiline && '\n' == js[i]) {
       withinSingle = false;
       buf += js[i];
-    } else if (!withinSingle && !withinMultiline && ('\'' == js[i] || '"' == js[i])) {
-      withinString = !withinString;
+    } else if (!withinSingle && !withinMultiline && !withinEscapeChar && ('\'' == js[i] || '"' == js[i])) {
+      if(withinString) {
+        if(js[i] == currentStringQuoteChar) {
+          withinString = false;
+        }
+      } else {
+        withinString = true;
+        currentStringQuoteChar = js[i];
+      }
+
       buf += js[i];
     } else {
       buf += js[i];

--- a/test/dox.test.js
+++ b/test/dox.test.js
@@ -947,5 +947,20 @@ module.exports = {
       comments[0].tags[2].html.should.equal("<p>NPM:lodash.merge</p>");
       done();
     });
-  }
+  },
+
+  'test that quotes within strings are correctly handled': function (done) {
+    fixture('string-quotes.js', function (err, str){
+      var comments = dox.parseComments(str);
+      comments.length.should.equal(7);
+      comments[0].description.full.should.equal("<p>One</p>");
+      comments[1].description.full.should.equal("<p>Two</p>");
+      comments[2].description.full.should.equal("<p>Three</p>");
+      comments[3].description.full.should.equal("<p>Four</p>");
+      comments[4].description.full.should.equal("<p>Five</p>");
+      comments[5].description.full.should.equal("<p>Six</p>");
+      comments[6].description.full.should.equal("<p>Seven</p>");
+      done();
+    });
+  },
 };

--- a/test/fixtures/string-quotes.js
+++ b/test/fixtures/string-quotes.js
@@ -1,0 +1,48 @@
+/**
+ * One
+ */
+function one() {
+	var a = "String with double quotes containing a single quote: '";
+}
+
+/**
+ * Two
+ */
+function two() {
+	var a = "String with double quotes containing an escaped single quote: \'";
+}
+
+/**
+ * Three
+ */
+function three() {
+	var a = "String with double quotes containing an escaped double quote: \"";
+}
+
+/**
+ * Four
+ */
+function four() {
+	var a = 'String with single quotes containing a double quote: "';
+}
+
+/**
+ * Five
+ */
+function five() {
+	var a = 'String with single quotes containing an escaped double quote: \"';
+}
+
+/**
+ * Six
+ */
+function six() {
+	var a = 'String with single quotes containing an escaped single quote: \'';
+}
+
+/**
+ * Seven
+ */
+function seven() {
+	var a = "Last function that should also get included";
+}


### PR DESCRIPTION
Fixes #149

String parsing was previously just assuming any single or double quote character encountered outside a comment was the start or end of a javascript string.

This PR correctly matches start and end quotes of javascript strings, and accounts for escaped quotes inside a string.

Have also added a somewhat comprehensive test case.