### PR TITLE
Fix vulnerability in jsdoctypeparser > lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "commander": "~2.20.0",
-    "jsdoctypeparser": "^1.2.0",
+    "jsdoctypeparser": "*",
     "markdown-it": "~9.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Low             Prototype Pollution                                           
                                                                                
  Package         lodash                                                        
                                                                                
  Patched in      >=4.17.5                                                      
                                                                                
  Dependency of   jsdoctest [dev]                                               
                                                                                
  Path            jsdoctest > dox > jsdoctypeparser > lodash                    
                                                                                
  More info       https://nodesecurity.io/advisories/577                        
                                                                                
                                                                                
  High            Prototype Pollution                                           
                                                                                
  Package         lodash                                                        
                                                                                
  Patched in      >=4.17.11                                                     
                                                                                
  Dependency of   jsdoctest [dev]                                               
                                                                                
  Path            jsdoctest > dox > jsdoctypeparser > lodash                    
                                                                                
  More info       https://nodesecurity.io/advisories/782                        
                                                                                
                                                                                
  High            Prototype Pollution                                           
                                                                                
  Package         lodash                                                        
                                                                                
  Patched in      >=4.17.12                                                     
                                                                                
  Dependency of   jsdoctest [dev]                                               
                                                                                
  Path            jsdoctest > dox > jsdoctypeparser > lodash                    
                                                                                
  More info       https://nodesecurity.io/advisories/1065                       
                                                                                
found 3 vulnerabilities (1 low, 2 high) in 1412 scanned packages
  3 vulnerabilities require manual review. See the full report for details.