### PR TITLE
docs: Fix simple typo, prototoype -> prototype

### DIFF
--- a/test/dox.test.js
+++ b/test/dox.test.js
@@ -375,7 +375,7 @@ module.exports = {
       comments[0].ctx.name.should.be.equal('Foo');
       comments[0].ctx.string.should.be.equal('Foo()');
 
-      // prototoype object
+      // prototype object
       comments[1].description.full.should.equal('<p>To be relevant or not to be. This is the question.</p>');
       comments[1].ctx.type.should.be.equal('prototype');
       comments[1].ctx.name.should.be.equal('Foo');


### PR DESCRIPTION
There is a small typo in test/dox.test.js.

Should read `prototype` rather than `prototoype`.

